### PR TITLE
fix: fix filtering of wpt results

### DIFF
--- a/src/handler.tsx
+++ b/src/handler.tsx
@@ -28,7 +28,7 @@ export const handler = router({
     if (commit == "favicon.ico") {
       return new Response("not found", { status: 404 });
     }
-    const filter = "/" + (params.filter as unknown as string[] ?? []).join("/") + "/";
+    const filter = Array.isArray(params.filter) ? `/${params.filter.join("/")}/` : "/";
 
     const tests = await wptDataForCommit(commit);
     const filtered = tests.filter((test) => test.file.startsWith(filter));

--- a/src/handler.tsx
+++ b/src/handler.tsx
@@ -28,7 +28,7 @@ export const handler = router({
     if (commit == "favicon.ico") {
       return new Response("not found", { status: 404 });
     }
-    const filter = "/" + (params.filter as unknown as string[] ?? []).join("/");
+    const filter = "/" + (params.filter as unknown as string[] ?? []).join("/") + "/";
 
     const tests = await wptDataForCommit(commit);
     const filtered = tests.filter((test) => test.file.startsWith(filter));


### PR DESCRIPTION
The entry `FileAPI/fileReader.any.html` appears as `Reader.any.html` in `FileAPI/file` directory (ref: https://wpt-deno-land-e0eaa254.deno.dev/3b220c64f615a4e18346e8a1c07ad7b1aae9fcc6/FileAPI/file ), but this should only appear in `FileAPI/` directory as `fileReader.any.html`. This PR fixes it.