### PR TITLE
feat: add view in github link

### DIFF
--- a/src/Data.tsx
+++ b/src/Data.tsx
@@ -63,7 +63,24 @@ export function Data(
   return (
     <div class={tw`max-w-screen-md mx-auto p-6`}>
       <Header />
-      <p class={tw`mt-8`}>{filter}</p>
+      <p class={tw`mt-8`}>
+	{filter}{` `}
+        {filter.endsWith('.html') ? (
+	  <a
+	    class={tw`text-blue-500 hover:underline`}
+	    href={`https://github.com/denoland/wpt/blob/master${filter.replace(/\.html$/, ".js")}`}
+	  >
+	    View in GitHub
+	  </a>
+        ) : (
+	  <a
+	    class={tw`text-blue-500 hover:underline`}
+	    href={`https://github.com/denoland/wpt/tree/master${filter}`}
+	  >
+	    View in GitHub
+	  </a>
+	)}
+      </p>
       <p class={tw`mt-4`}>
         <span class={tw`font-bold`}>{filtered.length}</span>{" "}
         matching WPT tests for commit{" "}

--- a/src/Data.tsx
+++ b/src/Data.tsx
@@ -63,21 +63,21 @@ export function Data(
   return (
     <div class={tw`max-w-screen-md mx-auto p-6`}>
       <Header />
-      <p class={tw`mt-8`}>
-	{filter}{` `}
+      <p class={tw`mt-8`}>{filter}</p>
+      <p class={tw`mt-4`}>
         {filter.endsWith('.html') ? (
 	  <a
 	    class={tw`text-blue-500 hover:underline`}
 	    href={`https://github.com/denoland/wpt/blob/master${filter.replace(/\.html$/, ".js")}`}
 	  >
-	    View in GitHub
+	    View on GitHub
 	  </a>
         ) : (
 	  <a
 	    class={tw`text-blue-500 hover:underline`}
 	    href={`https://github.com/denoland/wpt/tree/master${filter}`}
 	  >
-	    View in GitHub
+	    View on GitHub
 	  </a>
 	)}
       </p>


### PR DESCRIPTION
Adds 'View in GitHub' link next to the filter name. I think this would be useful for exploring what test cases are acutally executed for each test case.

<img width="827" alt="スクリーンショット 2021-06-07 15 48 13" src="https://user-images.githubusercontent.com/613956/120971632-d57ae900-c7a7-11eb-8bc7-129e1f966e61.png">
